### PR TITLE
Add a more concise `state.files` description in App-test.js

### DIFF
--- a/test/App-test.js
+++ b/test/App-test.js
@@ -19,7 +19,7 @@ describe('<App />', function() {
   });
 
   describe('state.files', function() {
-    it('should be empty array', function() {
+    it('should be array with one empty string', function() {
       const wrapper = shallow(<App />);
       expect(wrapper.state('files')).toEqual(['']);
     });


### PR DESCRIPTION
'should be empty array' suggests that `state.files` should equal `[]`. 'should be array with one empty string' is a bit more concise, since it is explicitly asking for an array with a string inside (`[""]`)